### PR TITLE
Fix Loading Race Condition

### DIFF
--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -11,7 +11,7 @@
         <!-- Font Awesome icons (free version)-->
         <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>
         <!-- Script for fetching data from backend -->
-        <script src="/static/js/fetch_data.js" async></script>
+        <script src="/static/js/fetch_data.js"></script>
 <!--        <script src="{{ url_for('static', filename='fetch_data.js') }}"></script>-->
         <!-- Google fonts-->
         <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Remove the `async` from your script tag for loading the `fetch_data.js` script. Using it is leading to a race condition where it tells the script to download in parallel with the loading of the DOM. This is bad because your loaded script depends on the page NOT being loaded. So sometimes, the page would already be loaded by the time you add your window event handler, but it would never execute because technically the page has already loaded.

I think this is the correct implementation for now, but another option is found here: https://stackoverflow.com/a/39993724